### PR TITLE
Update .gitpod.Dockerfile

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -10,6 +10,9 @@ RUN curl -O https://download.clojure.org/install/linux-install-1.10.1.536.sh \
 # Install rlwrap
 RUN sudo apt-get install -y rlwrap
 
+# Install asciidoc for project doc previews
+RUN sudo apt-get install -y  asciidoctor
+
 # Install Lein
 # RUN curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > lein \
 #     && sudo mv lein /usr/local/bin/lein \


### PR DESCRIPTION
As soon as the project was opened, there was an error as gitpod is trying to render the readme by default. Hence installing asciidoctor as part of the image.